### PR TITLE
Allow closures when calling throw_if

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -400,9 +400,10 @@ if (! function_exists('throw_if')) {
      * @template TValue
      * @template TParams of mixed
      * @template TException of \Throwable
+     * @template TExceptionValue of TException|class-string<TException>|string
      *
      * @param  TValue  $condition
-     * @param  TException|\Closure(TParams): mixed|class-string<TException>|string  $exception
+     * @param  Closure(TParams): TExceptionValue|TExceptionValue  $exception
      * @param  TParams  ...$parameters
      * @return ($condition is true ? never : ($condition is non-empty-mixed ? never : TValue))
      *
@@ -431,11 +432,13 @@ if (! function_exists('throw_unless')) {
      * Throw the given exception unless the given condition is true.
      *
      * @template TValue
+     * @template TParams of mixed
      * @template TException of \Throwable
+     * @template TExceptionValue of TException|class-string<TException>|string
      *
      * @param  TValue  $condition
-     * @param  TException|class-string<TException>|string  $exception
-     * @param  mixed  ...$parameters
+     * @param  Closure(TParams): TExceptionValue|TExceptionValue  $exception
+     * @param  TParams  ...$parameters
      * @return ($condition is false ? never : ($condition is non-empty-mixed ? TValue : never))
      *
      * @throws TException

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -398,11 +398,12 @@ if (! function_exists('throw_if')) {
      * Throw the given exception if the given condition is true.
      *
      * @template TValue
+     * @template TParams of mixed
      * @template TException of \Throwable
      *
      * @param  TValue  $condition
-     * @param  TException|class-string<TException>|string  $exception
-     * @param  mixed  ...$parameters
+     * @param  TException|\Closure(TParams): mixed|class-string<TException>|string  $exception
+     * @param  TParams  ...$parameters
      * @return ($condition is true ? never : ($condition is non-empty-mixed ? never : TValue))
      *
      * @throws TException
@@ -410,6 +411,10 @@ if (! function_exists('throw_if')) {
     function throw_if($condition, $exception = 'RuntimeException', ...$parameters)
     {
         if ($condition) {
+            if ($exception instanceof Closure) {
+                $exception = $exception(...$parameters);
+            }
+
             if (is_string($exception) && class_exists($exception)) {
                 $exception = new $exception(...$parameters);
             }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -832,6 +832,30 @@ class SupportHelpersTest extends TestCase
         throw_if(true, LogicException::class, 'test');
     }
 
+    public function testThrowClosureException()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('test');
+
+        throw_if(true, fn () => new \Exception('test'));
+    }
+
+    public function testThrowClosureWithParamsException()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('test');
+
+        throw_if(true, fn (string $message) => new \Exception($message), 'test');
+    }
+
+    public function testThrowClosureStringWithParamsException()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('test');
+
+        throw_if(true, fn () => \Exception::class, 'test');
+    }
+
     public function testThrowUnless()
     {
         $this->expectException(LogicException::class);


### PR DESCRIPTION
This enhancement allows defining the exception provided to the throw_if helper as a Closure.

The closure should return either the exception to be thrown or the class type of the exception represented as a string.

This is a quality of life improvement. Take the following:

```php

// a success will return an array, a failure will return an instance of CustomResponse
$apiCall = app()->call(MakeApiCall::class);

// the below will fail on a successful API call because the exception is always exected
throw_if($apiResponse instanceof CustomResponse, new \Exception($apiResponse->message));

// to counter this, we can put our exception creation logic into a closure. This will now
// only be evaluated if the $apiResponse is an instance of CustomResponse
throw_if($apiResponse instanceof CustomResponse, fn() => new \Exception($apiResponse->message));
```

I have added this functionality with testing and the ability to preserve existing functionality, such as passing parameters through to the closure